### PR TITLE
Bug fixes and No CNV for unmatched

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -3,4 +3,4 @@
 [ -e report ] && rm -rf report
 mkdir report
 cp -r ../* report/
-docker build -t "mskcc/argos_report:dev" .
+docker build -t "mskcc/argos_report:1.0.5" .

--- a/container/build.sh
+++ b/container/build.sh
@@ -3,4 +3,4 @@
 [ -e report ] && rm -rf report
 mkdir report
 cp -r ../* report/
-docker build -t "mskcc/argos_report:1.0.4" .
+docker build -t "mskcc/argos_report:dev" .

--- a/cwl/project_level_report.cwl
+++ b/cwl/project_level_report.cwl
@@ -10,7 +10,7 @@ requirements:
   StepInputExpressionRequirement: {}
   InlineJavascriptRequirement: {}
   DockerRequirement:
-    dockerPull: mskcc/argos_report:dev
+    dockerPull: mskcc/argos_report:1.0.5
 
 inputs:
   request_id:

--- a/cwl/project_level_report.cwl
+++ b/cwl/project_level_report.cwl
@@ -10,7 +10,7 @@ requirements:
   StepInputExpressionRequirement: {}
   InlineJavascriptRequirement: {}
   DockerRequirement:
-    dockerPull: mskcc/argos_report:1.0.4
+    dockerPull: mskcc/argos_report:dev
 
 inputs:
   request_id:

--- a/cwl/report.cwl
+++ b/cwl/report.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 baseCommand: [ "compile_sample_level.R" ]
 requirements:
   DockerRequirement:
-    dockerPull: mskcc/argos_report:dev
+    dockerPull: mskcc/argos_report:1.0.5
 
 inputs:
   request_id:

--- a/cwl/report.cwl
+++ b/cwl/report.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 baseCommand: [ "compile_sample_level.R" ]
 requirements:
   DockerRequirement:
-    dockerPull: mskcc/argos_report:1.0.4
+    dockerPull: mskcc/argos_report:dev
 
 inputs:
   request_id:


### PR DESCRIPTION
- No mutation (after filtering) samples were not been able to successfully identified as matched or unmatched, so for now those samples will cause a Fatal Error and will be run manually, until we fix this issue.
- UnMatched samples' CNV is no longer being reported
- if SEX column was all Females (Fs) R assumes this column to be logical values, so needed to say column type explicitly
- fixed, temporarily hiding MSI, commented out the wrong line
- updated Fatal Error messages